### PR TITLE
Update Dockerfile

### DIFF
--- a/cmd/verysimple/Dockerfile
+++ b/cmd/verysimple/Dockerfile
@@ -4,6 +4,6 @@ WORKDIR /build
 RUN git clone https://github.com/e1732a364fed/v2ray_simple.git . && \
     make -C ./cmd/verysimple
 
-FROM scratch
-COPY --from=builder /build/cmd/verysimple/verysimple /verysimple
-ENTRYPOINT ["/verysimple"]
+FROM alpine:latest
+COPY --from=builder /build/cmd/verysimple/verysimple /bin/verysimple
+ENTRYPOINT ["/bin/verysimple"]

--- a/cmd/verysimple/docker-compose.yaml
+++ b/cmd/verysimple/docker-compose.yaml
@@ -6,5 +6,6 @@ services:
     network_mode: "host"
     volumes:
       - "/etc/verysimple:/etc/verysimple"
+      - "/etc/domain-list-community:/bin/geosite"
     command: -c /etc/verysimple/server.toml
-    image: verysimple
+    image: ghcr.io/e1732a364fed/v2ray_simple:latest


### PR DESCRIPTION
因为verysimple会自动下载mmdb文件，所以不能将空镜像作为母镜像